### PR TITLE
decode optimization using unbuffered dd instead of sed

### DIFF
--- a/ocdec.sh
+++ b/ocdec.sh
@@ -139,7 +139,8 @@ function decryptFile() {
     iv=$(echo -n "$iv" | od -An -tx1 | tr -dc '[:xdigit:]' )
     # decode chunk
     openssl enc -AES-256-CFB -d -nosalt -base64 -A -K $decFileKeyContentHEX -iv $iv -in <(echo "$payload")
-    done <<<`sed -r 's/^HBEGIN:.+:HEND-*//' <"${USER}/$encFilePath"` # pipe the encrypted file without head into the loop
+    #done <<<`sed -r 's/^HBEGIN:.+:HEND-*//' <"${USER}/$encFilePath"` # pipe the encrypted file without head into the loop
+    done < <(dd bs=$chunkSize skip=1 if="${USER}/$encFilePath")
   # --- Decrypt the file ---
 }
 


### PR DESCRIPTION
redirecting the output of `sed` into the main loop of the decryption process lead to an unneccessary execution time and memory usage as the call had to end before the loop started it's work.